### PR TITLE
Fetch one IStream reference and keep it until the file is written

### DIFF
--- a/mp4mux/MuxFilter.h
+++ b/mp4mux/MuxFilter.h
@@ -223,6 +223,7 @@ public:
 
 private:
     Mpeg4Mux* m_pMux;
+	IStream* m_pIStream;
     CCritSec m_csWrite;
     bool m_bUseIStream;
     LONGLONG m_llBytes;


### PR DESCRIPTION
* before, we repeatedly fetched an IStream reference into an IStreamPtr and soon after released it again
* this led the attached FileWriter to constantly open and close the associated file, hurting performance
* affects #19
* fixes #21